### PR TITLE
bump kind to 0.15

### DIFF
--- a/kind/action.yml
+++ b/kind/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Install KinD
       shell: bash
       run: |
-        sudo curl -Lo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+        sudo curl -Lo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.15.0/kind-linux-amd64
         sudo curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
         sudo chmod +x /usr/local/bin/kind /usr/local/bin/kubectl
     - name: Start KinD


### PR DESCRIPTION
Update to [KinD 0.15.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.15.0)

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>