### PR TITLE
Add dependency trackers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/redhat-chaos/actions
+
+go 1.19
+
+require (
+	sigs.k8s.io/kind v0.16.0
+)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/redhat-chaos/krkn-hub@main


### PR DESCRIPTION
Adding files for letting GitHub dependabot know we are consuming other projects in order to get notifications on new versions / CVE disclosure.