### PR TITLE
Adding auto push to prow scripts

### DIFF
--- a/krkn-hub/action.yml
+++ b/krkn-hub/action.yml
@@ -30,3 +30,5 @@ runs:
       shell: bash
       run: docker-compose push
       working-directory: ./krkn-hub
+    - name: Make push to Prow-Scripts
+      uses: redhat-chaos/actions/prow-scripts@main

--- a/prow-scripts/auto_push.yml
+++ b/prow-scripts/auto_push.yml
@@ -1,0 +1,24 @@
+name: Auto Push 
+on:
+  workflow_dispatch:
+    inputs:
+      test_list:
+        description: Only run tests that match the regular expression
+        default: ""
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@main
+    - name: Update README with current date/time
+      run: |
+        current_date=$(date +"%H:%M %b %d %Y")
+        sed -i "s/[0-9]\{2\}:[0-9]\{2\} [A-Z][a-z]\{2\} [0-9]\{2\} [0-9]\{4\}/$current_date/g" README.md
+        git config --global user.name 'Auto User'
+        git config --global user.email 'auto@users.noreply.github.com'
+        git add README.md
+        git commit -am "Automated readme update"
+        git push


### PR DESCRIPTION
Test - push prow-scripts when krkn/krkn-hub is rebuilt

Think this can only be fully tested when its merged in and the krkn-hub action is called