### PR TITLE
testing newer kind version

### DIFF
--- a/.kind-config.yml
+++ b/.kind-config.yml
@@ -1,8 +1,8 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-  - role: control-plane
-  - role: control-plane
-  - role: control-plane
-  - role: worker
-  - role: worker
+- role: control-plane
+- role: control-plane
+- role: control-plane
+- role: worker
+- role: worker

--- a/kind/action.yml
+++ b/kind/action.yml
@@ -11,14 +11,14 @@ runs:
     - name: Install KinD
       shell: bash
       run: |
-        sudo curl -Lo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.16.0/kind-linux-amd64
+        sudo curl -Lo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-linux-amd64
         sudo curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
         sudo chmod +x /usr/local/bin/kind /usr/local/bin/kubectl
     - name: Start KinD
       shell: bash
       run: |
-        if [ -f kind-config.yml ]; then
-          kind create cluster --wait 300s --config=kind-config.yml
+        if [ -f .kind-config.yml ]; then
+          kind create cluster --wait 300s --config=.kind-config.yml
         else
           kind create cluster --wait 300s
         fi


### PR DESCRIPTION
Want to update the kind version because it was 10 versions behind
Also, the configuration was only creating 1 master node because it wasn't able to find the file to create. This will now create a multi node cluster and hopefully also help with our inconsistent tests on krkn-lib